### PR TITLE
Target Python 3.12 AST and fix warnings

### DIFF
--- a/src/fluent_compiler/ast_compat.py
+++ b/src/fluent_compiler/ast_compat.py
@@ -24,6 +24,7 @@ If a new Python version changes/breaks the AST for existing features, the proces
 
 """
 import ast
+import sys
 
 # This is a very limited subset of Python AST:
 # - only the things needed by codegen.py
@@ -43,12 +44,10 @@ Index = ast.Index
 List = ast.List
 Load = ast.Load
 Module = ast.Module
-Num = ast.Num
 Or = ast.Or
 Pass = ast.Pass
 Return = ast.Return
 Store = ast.Store
-Str = ast.Str
 Subscript = ast.Subscript
 Tuple = ast.Tuple
 arguments = ast.arguments
@@ -58,10 +57,27 @@ Attribute = ast.Attribute
 Call = ast.Call
 FunctionDef = ast.FunctionDef
 Name = ast.Name
-NameConstant = ast.NameConstant
 Try = ast.Try
 arg = ast.arg
 keyword = ast.keyword
+
+
+if sys.version_info >= (3, 8):
+    Constant = ast.Constant
+else:
+    # For Python 3.6/3.7, in terms of runtime behaviour we could also use
+    # Constant for Str/Num, but this seems to trigger bugs when decompiling with
+    # ast_decompiler, which is needed by tests. So we use the more normal
+    # ast that Python 3.6/3.7 use for this code.
+    def Constant(arg, **kwargs):
+        if isinstance(arg, str):
+            return ast.Str(arg, **kwargs)
+        elif isinstance(arg, (int, float)):
+            return ast.Num(arg, **kwargs)
+        elif arg is None:
+            return ast.NameConstant(arg, **kwargs)
+        else:
+            raise NotImplementedError(f"Constant not implemented for args of type {type(arg)}")
 
 
 def traverse(ast_node, func):

--- a/src/fluent_compiler/codegen.py
+++ b/src/fluent_compiler/codegen.py
@@ -531,7 +531,7 @@ class String(Expression):
         self.string_value = string_value
 
     def as_ast(self):
-        return ast.Str(
+        return ast.Constant(
             self.string_value,
             kind=None,  # 3.8, indicates no prefix, needed only for tests
             **DEFAULT_AST_ARGS,
@@ -552,7 +552,7 @@ class Number(Expression):
         self.type = type(number)
 
     def as_ast(self):
-        return ast.Num(n=self.number, **DEFAULT_AST_ARGS)
+        return ast.Constant(self.number, **DEFAULT_AST_ARGS)
 
     def __repr__(self):
         return f"Number({repr(self.number)})"
@@ -729,7 +729,7 @@ class FunctionCall(Expression):
                     ast.keyword(
                         arg=None,
                         value=ast.Dict(
-                            keys=[ast.Str(k, kind=None, **DEFAULT_AST_ARGS) for k in kwarg_names],
+                            keys=[ast.Constant(k, kind=None, **DEFAULT_AST_ARGS) for k in kwarg_names],
                             values=[v.as_ast() for v in kwarg_values],
                             **DEFAULT_AST_ARGS,
                         ),
@@ -806,7 +806,7 @@ class NoneExpr(Expression):
     type = type(None)
 
     def as_ast(self):
-        return ast.NameConstant(value=None, **DEFAULT_AST_ARGS)
+        return ast.Constant(value=None, **DEFAULT_AST_ARGS)
 
 
 class BinaryOperator(Expression):


### PR DESCRIPTION
Python 3.8 and later use `ast.Constant` and not the subclasses `ast.Str`, `Num` etc. and the latter are now deprecated.