### PR TITLE
refactor: move `ast_compat.traverse` to `codegen`

### DIFF
--- a/src/fluent_compiler/ast_compat.py
+++ b/src/fluent_compiler/ast_compat.py
@@ -60,6 +60,7 @@ Name = ast.Name
 Try = ast.Try
 arg = ast.arg
 keyword = ast.keyword
+walk = ast.walk
 
 
 if sys.version_info >= (3, 8):

--- a/src/fluent_compiler/ast_compat.py
+++ b/src/fluent_compiler/ast_compat.py
@@ -78,11 +78,3 @@ else:
             return ast.NameConstant(arg, **kwargs)
         else:
             raise NotImplementedError(f"Constant not implemented for args of type {type(arg)}")
-
-
-def traverse(ast_node, func):
-    """
-    Apply 'func' to ast_node (which is `ast.*` object)
-    """
-    for node in ast.walk(ast_node):
-        func(node)

--- a/src/fluent_compiler/codegen.py
+++ b/src/fluent_compiler/codegen.py
@@ -406,7 +406,7 @@ class Function(Scope, Statement, PythonAst):
             def add_lineno(node):
                 node.lineno = self.source.row
 
-            ast.traverse(func_def, add_lineno)
+            traverse(func_def, add_lineno)
         return func_def
 
     def add_return(self, value):
@@ -843,6 +843,14 @@ class BoolOp(BinaryOperator):
 
 class Or(BoolOp):
     op = ast.Or
+
+
+def traverse(ast_node, func):
+    """
+    Apply 'func' to ast_node (which is `ast.*` object)
+    """
+    for node in ast.walk(ast_node):
+        func(node)
 
 
 def simplify(codegen_ast, simplifier):


### PR DESCRIPTION
See https://github.com/django-ftl/fluent-compiler/pull/23#discussion_r1342980905.