### PR TITLE
Fixed bug in compiler.py related to variable reuse

### DIFF
--- a/src/fluent_compiler/compiler.py
+++ b/src/fluent_compiler/compiler.py
@@ -909,7 +909,7 @@ def compile_expr_variable_reference(argument, block, compiler_env):
 
     if block.scope.has_assignment(arg_tmp_name):  # already assigned to this, can re-use
         if not wrap_with_handle_argument:
-            return block.variable(arg_tmp_name)
+            return block.scope.variable(arg_tmp_name)
 
         block.add_assignment(arg_handled_tmp_name, handle_argument_func_call)
         return block.scope.variable(arg_handled_tmp_name)


### PR DESCRIPTION
This bug caused the following error:

> AttributeError: 'Block' object has no attribute 'variable'

You can easily reproduce the bug trying to use 2 functions in 1 text with same variable like this:

`example = My name is { $name->
  [Peter] Peter11
  *[other] Jane11
  }

  My gender is { $name->
  [Peter] Male
  *[other] Female
  }`