### PR TITLE
Optimisation: Avoid set copies when compiling files

### DIFF
--- a/src/fluent_compiler/codegen.py
+++ b/src/fluent_compiler/codegen.py
@@ -122,14 +122,35 @@ class Scope:
             names = names | self.parent_scope.names_in_use()
         return names
 
+    def is_name_in_use(self, name: str) -> bool:
+        if name in self.names:
+            return True
+
+        if self.parent_scope is None:
+            return False
+
+        return self.parent_scope.is_name_in_use(name)
+
     def function_arg_reserved_names(self):
         names = self._function_arg_reserved_names
         if self.parent_scope is not None:
             names = names | self.parent_scope.function_arg_reserved_names()
         return names
 
+    def is_name_reserved_function_arg(self, name: str) -> bool:
+        if name in self._function_arg_reserved_names:
+            return True
+
+        if self.parent_scope is None:
+            return False
+
+        return self.parent_scope.is_name_reserved_function_arg(name)
+
     def all_reserved_names(self):
         return self.names_in_use() | self.function_arg_reserved_names()
+
+    def is_name_reserved(self, name: str) -> bool:
+        return self.is_name_in_use(name) or self.is_name_reserved_function_arg(name)
 
     def reserve_name(self, requested, function_arg=False, is_builtin=False, properties=None):
         """

--- a/src/fluent_compiler/codegen.py
+++ b/src/fluent_compiler/codegen.py
@@ -168,7 +168,7 @@ class Scope:
 
         if function_arg:
             if self.is_name_reserved_function_arg(requested):
-                assert requested not in self.names_in_use()
+                assert not self.is_name_in_use(requested)
                 return _add(requested)
             if self.is_name_reserved(requested):
                 raise AssertionError(f"Cannot use '{requested}' as argument name as it is already in use")
@@ -332,7 +332,7 @@ class Block(PythonAstList):
 
            x = value
         """
-        if name not in self.scope.names_in_use():
+        if not self.scope.is_name_in_use(name):
             raise AssertionError(f"Cannot assign to unreserved name '{name}'")
 
         if self.scope.has_assignment(name):
@@ -391,7 +391,7 @@ class Function(Scope, Statement, PythonAst):
         if args is None:
             args = ()
         for arg in args:
-            if arg in self.names_in_use():
+            if self.is_name_in_use(arg):
                 raise AssertionError(f"Can't use '{arg}' as function argument name because it shadows other names")
             self.reserve_name(arg, function_arg=True)
         self.args = args
@@ -687,7 +687,7 @@ class VariableReference(Expression):
     child_elements = []
 
     def __init__(self, name, scope):
-        if name not in scope.names_in_use():
+        if not scope.is_name_in_use(name):
             raise AssertionError(f"Cannot refer to undefined variable '{name}'")
         self.name = name
         self.type = scope.get_name_properties(name).get(PROPERTY_TYPE, UNKNOWN_TYPE)
@@ -708,7 +708,7 @@ class FunctionCall(Expression):
     child_elements = ["args", "kwargs"]
 
     def __init__(self, function_name, args, kwargs, scope, expr_type=UNKNOWN_TYPE):
-        if function_name not in scope.names_in_use():
+        if not scope.is_name_in_use(function_name):
             raise AssertionError(f"Cannot call unknown function '{function_name}'")
         self.function_name = function_name
         self.args = list(args)

--- a/src/fluent_compiler/codegen.py
+++ b/src/fluent_compiler/codegen.py
@@ -161,14 +161,14 @@ class Scope:
 
         used = self.all_reserved_names()
 
-        # We need to also protect against using keywords ('class', 'def' etc.)
-        # i.e. count all keywords as 'used'.
-        # However, some builtins are also keywords (e.g. 'None'), and so
-        # if a builtin is being reserved, don't check against the keyword list
-        if not is_builtin:
-            used = used | set(keyword.kwlist)
-
         def _is_name_allowed(name: str) -> bool:
+            # We need to also protect against using keywords ('class', 'def' etc.)
+            # i.e. count all keywords as 'used'.
+            # However, some builtins are also keywords (e.g. 'None'), and so
+            # if a builtin is being reserved, don't check against the keyword list
+            if (not is_builtin) and keyword.iskeyword(name):
+                return False
+
             return name not in used
 
         while not _is_name_allowed(attempt):

--- a/src/fluent_compiler/codegen.py
+++ b/src/fluent_compiler/codegen.py
@@ -167,7 +167,7 @@ class Scope:
             return final
 
         if function_arg:
-            if requested in self.function_arg_reserved_names():
+            if self.is_name_reserved_function_arg(requested):
                 assert requested not in self.names_in_use()
                 return _add(requested)
             if self.is_name_reserved(requested):

--- a/src/fluent_compiler/codegen.py
+++ b/src/fluent_compiler/codegen.py
@@ -160,15 +160,21 @@ class Scope:
         # take into account parent scope when assigning names.
 
         used = self.all_reserved_names()
+
         # We need to also protect against using keywords ('class', 'def' etc.)
         # i.e. count all keywords as 'used'.
         # However, some builtins are also keywords (e.g. 'None'), and so
         # if a builtin is being reserved, don't check against the keyword list
         if not is_builtin:
             used = used | set(keyword.kwlist)
-        while attempt in used:
+
+        def _is_name_allowed(name: str) -> bool:
+            return name not in used
+
+        while not _is_name_allowed(attempt):
             attempt = cleaned + str(count)
             count += 1
+
         return _add(attempt)
 
     def reserve_function_arg_name(self, name):

--- a/src/fluent_compiler/codegen.py
+++ b/src/fluent_compiler/codegen.py
@@ -116,12 +116,6 @@ class Scope:
         self._properties = {}
         self._assignments = {}
 
-    def names_in_use(self):
-        names = self.names
-        if self.parent_scope is not None:
-            names = names | self.parent_scope.names_in_use()
-        return names
-
     def is_name_in_use(self, name: str) -> bool:
         if name in self.names:
             return True
@@ -131,12 +125,6 @@ class Scope:
 
         return self.parent_scope.is_name_in_use(name)
 
-    def function_arg_reserved_names(self):
-        names = self._function_arg_reserved_names
-        if self.parent_scope is not None:
-            names = names | self.parent_scope.function_arg_reserved_names()
-        return names
-
     def is_name_reserved_function_arg(self, name: str) -> bool:
         if name in self._function_arg_reserved_names:
             return True
@@ -145,9 +133,6 @@ class Scope:
             return False
 
         return self.parent_scope.is_name_reserved_function_arg(name)
-
-    def all_reserved_names(self):
-        return self.names_in_use() | self.function_arg_reserved_names()
 
     def is_name_reserved(self, name: str) -> bool:
         return self.is_name_in_use(name) or self.is_name_reserved_function_arg(name)

--- a/src/fluent_compiler/codegen.py
+++ b/src/fluent_compiler/codegen.py
@@ -170,7 +170,7 @@ class Scope:
             if requested in self.function_arg_reserved_names():
                 assert requested not in self.names_in_use()
                 return _add(requested)
-            if requested in self.all_reserved_names():
+            if self.is_name_reserved(requested):
                 raise AssertionError(f"Cannot use '{requested}' as argument name as it is already in use")
 
         cleaned = cleanup_name(requested)
@@ -180,8 +180,6 @@ class Scope:
         # To avoid shadowing of global names in local scope, we
         # take into account parent scope when assigning names.
 
-        used = self.all_reserved_names()
-
         def _is_name_allowed(name: str) -> bool:
             # We need to also protect against using keywords ('class', 'def' etc.)
             # i.e. count all keywords as 'used'.
@@ -190,7 +188,7 @@ class Scope:
             if (not is_builtin) and keyword.iskeyword(name):
                 return False
 
-            return name not in used
+            return not self.is_name_reserved(name)
 
         while not _is_name_allowed(attempt):
             attempt = cleaned + str(count)
@@ -207,7 +205,7 @@ class Scope:
         # To keep things simple, and the generated code predictable, we reserve
         # names for all function arguments in a separate scope, and insist on
         # the exact names
-        if name in self.all_reserved_names():
+        if self.is_name_reserved(name):
             raise AssertionError(f"Can't reserve '{name}' as function arg name as it is already reserved")
         self._function_arg_reserved_names.add(name)
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -65,7 +65,7 @@ class TestCodeGen(unittest.TestCase):
         scope.reserve_function_arg_name("arg_name")
         scope.reserve_name("myfunc")
         func = codegen.Function("myfunc", args=["arg_name"], parent_scope=scope)
-        self.assertNotIn("arg_name2", func.all_reserved_names())
+        self.assertFalse(func.is_name_reserved("arg_name2"))
 
     def test_reserve_name_nested(self):
         parent = codegen.Scope()


### PR DESCRIPTION
This PR aims to speed up file compilation by avoid unnecessary copying of sets.

Previously, the `Scope` class had methods of the form:

```py3
def names_in_use(self):
	names = self.names
    if self.parent_scope is not None:
        # This create a new set
        result = result | self.parent_scope.names_in_use()

    return names
```

These sets were used by various other codegen functions to check for membership. With large fluent files, this results in a lot of unnecessary set creation, as there might be many names added to a given scope.

This PR replaces these methods with query equivalents of the form:

```py3
def is_name_in_use(self, name: str) -> bool:
    if name in self.names:
        return True

    if self.parent_scope is None:
        return False

    return self.parent_scope.is_name_in_use(name)
```

By doing this we speed up compiling by about 60%. For the 10K line benchmark added in #30, it reduces the time from ~10s to ~4s.

<details>
<summary>Benchmark before</summary>

```
❯ ./compiler.py -k 10k --benchmark-warmup=off
================================================================================================= test session starts ==================================================================================================
platform darwin -- Python 3.10.14, pytest-8.2.1, pluggy-1.5.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Volumes/Code/fluent-compiler
configfile: pyproject.toml
plugins: anyio-4.3.0, hypothesis-6.102.6, benchmark-4.0.0
collected 4 items / 3 deselected / 1 selected                                                                                                                                                                          

compiler.py .                                                                                                                                                                                                    [100%]


----------------------------------------------- benchmark: 1 tests -----------------------------------------------
Name (time in s)                Min      Max    Mean  StdDev  Median     IQR  Outliers     OPS  Rounds  Iterations
------------------------------------------------------------------------------------------------------------------
test_file_with_10k_items     9.7863  10.1248  9.9234  0.1377  9.8794  0.2118       1;0  0.1008       5           1
------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
====================================================================================== 1 passed, 3 deselected in 69.96s (0:01:09) ======================================================================================
```
</details> 

<details>
<summary>Benchmark after</summary>

```
❯ ./compiler.py -k 10k --benchmark-warmup=off
================================================================================================= test session starts ==================================================================================================
platform darwin -- Python 3.10.14, pytest-8.2.1, pluggy-1.5.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Volumes/Code/fluent-compiler
configfile: pyproject.toml
plugins: anyio-4.3.0, hypothesis-6.102.6, benchmark-4.0.0
collected 4 items / 3 deselected / 1 selected                                                                                                                                                                          

compiler.py .                                                                                                                                                                                                    [100%]


----------------------------------------------- benchmark: 1 tests ----------------------------------------------
Name (time in s)                Min     Max    Mean  StdDev  Median     IQR  Outliers     OPS  Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------
test_file_with_10k_items     3.9957  4.0290  4.0099  0.0127  4.0051  0.0164       2;0  0.2494       5           1
-----------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
=========================================================================================== 1 passed, 3 deselected in 29.47s ==========================================================================================
```
</details>