### PR TITLE
Add forgotten closing parenthesis

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -25,7 +25,7 @@ You can add functions to the ones available to FTL authors by passing a
     ...   }
     ... """,
     ... functions={'OS': os_name})
-    >>> print(bundle.format('welcome')[0]
+    >>> print(bundle.format('welcome')[0])
     Welcome to Linux
 
 These functions can accept positional and keyword arguments, like the ``NUMBER``


### PR DESCRIPTION
In the Custom functions docs, a closing parenthesis was missing so I added it.